### PR TITLE
New hotkey: H - Toggle Video Control Bar

### DIFF
--- a/dist/options/options.html
+++ b/dist/options/options.html
@@ -34,6 +34,10 @@
         <td>- Toggle Theater Mode</td>
       </tr>
       <tr>
+        <td>H</td>
+        <td>- Toggle Video Control Bar</td>
+      </tr>
+      <tr>
         <td>Shift + P</td>
         <td>- Play previous video on playlist</td>
       </tr>

--- a/src/content-script-skillshare.js
+++ b/src/content-script-skillshare.js
@@ -4,6 +4,7 @@ const elVideo = document.documentElement.querySelector("video");
 const elVideoDiv = elVideo.parentElement;
 const elLessons = document.getElementsByClassName("session-item");
 const elSpeeds = document.querySelectorAll(".playback-speed-popover ul > li");
+const elControlBar = document.querySelector(".vjs-control-bar");
 
 // Make sure the controls will work as soon as the video is loaded
 elVideoDiv.focus();
@@ -166,14 +167,19 @@ function getIsFullScreen() {
   return document.webkitIsFullScreen || document.isFullScreen;
 }
 
-// Listen to F while in full-screen mode to exit it
 document.addEventListener("keydown", ({ code }) => {
-  if (getIsFullScreen()) {
-    switch (code) {
-      case "KeyF":
+
+  switch (code) {
+    case "KeyF": // Listen to F while in full-screen mode to exit it
+      if (getIsFullScreen()) {
         document.exitFullscreen();
-        break;
-    }
+      }
+      break;
+    case "KeyH": // Toggle control bar regardless of focus
+      {
+        elControlBar.style.visibility = elControlBar.style.visibility == 'hidden' ? 'visible' : 'hidden';
+      }
+      break;
   }
 });
 


### PR DESCRIPTION
Was very annoyed that the control bar wouldn't go away sometimes without refreshing the page. Was using your extension for the spacebar pausing an figured I could contribute.

I made the hotkey work anywhere regardless of focus so I don't have to click and pause the video by accident. I'd be happy to move it to focus only if you prefer. 

Awesome quick and simple extension! Thanks